### PR TITLE
Force removal of temporary directory, in case it contains read-only files

### DIFF
--- a/dpkg-diffs
+++ b/dpkg-diffs
@@ -56,7 +56,7 @@ function tempDirReady {
 # Cleanup temporary directory.
 function cleanupTempDir {
    if tempDirReady; then
-      rm -r "$tempDir" || (echo "Failed to remove temporary directory $tempDir." >&2; exit 1)
+      rm -rf "$tempDir" || (echo "Failed to remove temporary directory $tempDir." >&2; exit 1)
    fi
 }
 


### PR DESCRIPTION
If the target dpkg contains read-only files, the command fails when attempting to clean up its temporary directory.  Since we create this directory, it should be no problem to do an 'rm -rf "$tempDir"', instead of an 'rm -r "$tempDir"'.  This will prevent the command failure.
