### PR TITLE
apt works as well as aptitude; shellcheck’d

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -1,0 +1,49 @@
+# This workflow checks out code, performs a Codacy security scan
+# and integrates the results with the
+# GitHub Advanced Security code scanning feature.  For more information on
+# the Codacy security scan action usage and parameters, see
+# https://github.com/codacy/codacy-analysis-cli-action.
+# For more information on Codacy Analysis CLI in general, see
+# https://github.com/codacy/codacy-analysis-cli.
+
+name: Codacy Security Scan
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '32 22 * * 6'
+
+jobs:
+  codacy-security-scan:
+    name: Codacy Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
+      - name: Run Codacy Analysis CLI
+        uses: codacy/codacy-analysis-cli-action@1.1.0
+        with:
+          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
+          # You can also omit the token and run the tools that support default configurations
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          verbose: true
+          output: results.sarif
+          format: sarif
+          # Adjust severity of non-security issues
+          gh-code-scanning-compat: true
+          # Force 0 exit code to allow SARIF file generation
+          # This will handover control about PR rejection to the GitHub side
+          max-allowed-issues: 2147483647
+
+      # Upload the SARIF file generated in the previous step
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,2 @@
+- name: Super-Linter
+  uses: github/super-linter@v4.8.1

--- a/.github/workflows/sonarcloud-scan.yml
+++ b/.github/workflows/sonarcloud-scan.yml
@@ -1,0 +1,2 @@
+- name: SonarCloud Scan
+  uses: SonarSource/sonarcloud-github-action@v1.6

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,47 @@
+Author: egberts <egberts@github.com>
+Date:   Tue Oct 12 11:03:42 2021 -0400
+
+    If 'aptitude' isn't available, try 'apt'.
+    
+    (Lots of Debian host do not have 'aptitude'; but 'apt', they do)
+
+
+Author: egberts <egberts@github.com>
+Date:   Tue Oct 12 10:52:37 2021 -0400
+
+    - Revert "Some of the Debian system do not have 'aptitude' installed, but"
+    
+    - Some of the Debian system do not have 'aptitude' installed, but have 'apt' installed.  Make this script work with either.
+    
+    - Not all cases of invalid CLI options are being handled.  Add '*' to the case block.  (shellcheck SC2220)
+    
+    - Append additional handler to 'cd ...' with exit 1 (shellcheck SC2164)
+    
+    - Clarify the logic to ensure that it is not ambiguous.  (shellcheck SC2186)
+    
+    - 'read' mangles '/' so add an '-r' options to compensate for this.  (shellcheck SC2162)
+    
+    - If the script name has a space, compensate for this by adding quotes around the '$0'.
+    
+    - If the filename in a package has a space, compensate for this quirk by adding quotes around variables containing its blank-inserted filename.
+    
+    - Clarify logic to ensure that it is not ambiguous (shellcheck)
+    
+    - Add a shellcheck exemption requested for 'ls -A' which is immensely preferable over 'find $tempDir -type f'
+    
+    - Removed trailing spaces
+
+Author: Martin Leben <martin@leben.nu>
+Date:   Thu Oct 29 22:52:32 2020 +0100
+
+    Replace ":" (the epoch separator) with "%3a" to match the file name.
+
+Author: Perry Kundert <perry@hardconsulting.com>
+Date:   Fri Dec 7 13:55:26 2012 -0700
+
+    Force remove temporary directory, in case it contains files with read-only permission
+
+Author: Alex Bradley <a.bradley@alumni.cs.ubc.ca>
+Date:   Sat Jan 21 02:39:54 2012 -0800
+
+    Initial commit of dpkg-diffs.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-`dpkg-diffs‘ performs what Redhat's `rpm --verify` does and a bit more.
+`dpkg-diffs` performs what Redhat's `rpm --verify` does and a bit more.
 
 The script will assure that the installed package files are
 identical to its downloaded or cached package.

--- a/README.md
+++ b/README.md
@@ -21,4 +21,3 @@ Example run of dpkg-diffs against Chrony time server package.
     #
     echo $?
     0
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-`dpkg-diffs performs what Redhat's `rpm --verify` does and a bit more.
+`dpkg-diffs‘ performs what Redhat's `rpm --verify` does and a bit more.
 
 The script will assure that the installed package files are
 identical to its downloaded or cached package.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+`dpkg-verify` performs what Redhat's `rpm --verify` does.
+
+The script will assure that the installed package files are
+identical to its downloaded or cached package.
+
+Example run of dpkg-diffs against Chrony time server package.
+
+    # ./dpkg-diffs -d chrony
+    No package matching "chrony" found in cache.
+    [Working] Get:1 http://ftp-nyc.osuosl.org/debian bullseye/main amd64 chrony amd64 4.0-8 [286 kB]
+    chrony 14.4 kB/286 kB
+    Fetched 286 kB in 0s (2,683 kB/s)
+    Not present: /etc/chrony/conf.d
+    Not present: /etc/chrony/conf.d/README
+    Not present: /etc/chrony/sources.d
+    Not present: /etc/chrony/sources.d/README
+    Current file is symlink but package file is not: /lib
+    Exists but cannot read: /usr/share/chrony/chrony.keys
+    #
+    echo $?
+    0
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-`dpkg-verify` performs what Redhat's `rpm --verify` does.
+`dpkg-diffs performs what Redhat's `rpm --verify` does and a bit more.
 
 The script will assure that the installed package files are
 identical to its downloaded or cached package.
+
+Also, it will show any new or uncontrolled files in directories made by such package(s).
 
 Example run of dpkg-diffs against Chrony time server package.
 

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Example run of dpkg-diffs against Chrony time server package.
     #
     echo $?
     0
+
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/5c765a456eee486fb55d62ee7b5fd40d)](https://www.codacy.com/gh/egberts/dpkg-diffs/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=egberts/dpkg-diffs&amp;utm_campaign=Badge_Grade)

--- a/dpkg-diffs
+++ b/dpkg-diffs
@@ -153,7 +153,12 @@ function downloadDebFile {
    tempDirReady || die "Temporary directory not available. Cannot download with aptitude."
 
    cd "$tempDir" || echo "$tempDir directory is not accessible." || exit 1
-   aptitude download "$1" >&2 || die "Aptitude download failed."
+   whereis_aptitude="$(whereis -b aptitude | awk '{print $2}')"
+   if [ -n "$whereis_aptitude" ]; then
+       aptitude download "$1" >&2 || die "Aptitude download failed."
+   else
+       apt download "$1" >&2 || die "Apt download failed."
+   fi
    # Strip = and / modifiers from package name.
    pkgName=${1%[=/]*}
    echo "$tempDir"/"${pkgName}"*.deb

--- a/dpkg-diffs
+++ b/dpkg-diffs
@@ -20,7 +20,7 @@
 #
 
 SCRIPT_NAME=$(basename "$0")
-VERSION=0.1.1
+VERSION=0.1.2
 
 APT_ARCHIVE=/var/cache/apt/archives
 

--- a/dpkg-diffs
+++ b/dpkg-diffs
@@ -56,7 +56,7 @@ function tempDirReady {
 # Cleanup temporary directory.
 function cleanupTempDir {
    if tempDirReady; then
-      rm -r "$tempDir" || (echo "Failed to remove temporary directory $tempDir." >&2; exit 1)
+      rm -rf "$tempDir" || (echo "Failed to remove temporary directory $tempDir." >&2; exit 1)
    fi
 }
 

--- a/dpkg-diffs
+++ b/dpkg-diffs
@@ -120,7 +120,8 @@ function getCachedDebFile {
    candidates="$APT_ARCHIVE/${pkgNameSpec}_${version}_*.deb"
    if [ -z "$version" -o "$version" = "$1" ]; then
       if version_arch=$(dpkg-query -W -f '${Version}_${Architecture}' "$pkgNameSpec" 2>/dev/null); then
-         foundFile="$APT_ARCHIVE/${pkgNameSpec}_${version_arch}.deb"
+         # Replace ":" (the epoch separator) with "%3a" to match the file name.
+         foundFile="$APT_ARCHIVE/${pkgNameSpec}_${version_arch/:/%3a}.deb"
       else
          candidates="$APT_ARCHIVE/${pkgNameSpec}_*.deb"
       fi

--- a/dpkg-diffs
+++ b/dpkg-diffs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# dpkg-diffs - compare the filesystem tree of a Debian package to the 
+# dpkg-diffs - compare the filesystem tree of a Debian package to the
 # current filesystem tree, printing unified diffs for files that differ.
 #
 # Copyright (C) 2012 Alex Bradley.
@@ -19,8 +19,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-SCRIPT_NAME=$(basename $0)
-VERSION=0.1.0
+SCRIPT_NAME=$(basename "$0")
+VERSION=0.1.1
 
 APT_ARCHIVE=/var/cache/apt/archives
 
@@ -30,7 +30,7 @@ tempDir=
 
 # Print an error message and exit with nonzero status.
 function die {
-   if [ -n "$1" ]; then 
+   if [ -n "$1" ]; then
       echo "$1" >&2
    fi
    cleanupTempDir
@@ -39,9 +39,10 @@ function die {
 
 # Setup temporary directory.
 function setupTempDir {
-   tempDir=$(mktemp -d) || die "Unable to create temporary directory."
+   tempDir="$(mktemp -d)" || die "Unable to create temporary directory."
    tempDirReady || die "Temporary directory $tempDir not writable."
-   if [ $(ls -A "$tempDir" | wc -w) != 0 ]; then
+   # shellcheck disable=SC2012
+   if [ "$(ls -A "$tempDir" | wc -w)" != 0 ]; then
       # Paranoid check; this should never happen.
       echo "Error: temporary directory $tempDir provided by mktemp is not empty!" >&2
       exit 1
@@ -50,7 +51,7 @@ function setupTempDir {
 
 # Check if temporary directory exists and is writable.
 function tempDirReady {
-   [ -n "$tempDir" -a -d "$tempDir" -a -w "$tempDir" ]
+   [[ -n "$tempDir" && -d "$tempDir" && -w "$tempDir" ]]
 }
 
 # Cleanup temporary directory.
@@ -66,8 +67,8 @@ function cleanupTempDir {
 # unpacked, but dpkg-deb prints the names of files before it has finished
 # unpacking them.
 function waitNext {
-   read last || return
-   while read next; do
+   read -r last || return
+   while read -r next; do
       echo "$last"
       last=$next
    done
@@ -77,12 +78,12 @@ function waitNext {
 # Print usage information.
 function printUsage {
    cat <<EOF
-$SCRIPT_NAME $VERSION - compare the filesystem tree of a Debian package to the 
+$SCRIPT_NAME $VERSION - compare the filesystem tree of a Debian package to the
 current filesystem tree, printing unified diffs for files that differ.
 
-Copyright (C) 2012 Alex Bradley. This program comes with ABSOLUTELY NO 
-WARRANTY, and may be redistributed and/or modified under version 3 of the GNU 
-General Public License; please refer to the program source code or to the 
+Copyright (C) 2012 Alex Bradley. This program comes with ABSOLUTELY NO
+WARRANTY, and may be redistributed and/or modified under version 3 of the GNU
+General Public License; please refer to the program source code or to the
 LICENSE file distributed with the code for details.
 
 Usage: $SCRIPT_NAME -h
@@ -91,11 +92,11 @@ Usage: $SCRIPT_NAME -h
    or: $SCRIPT_NAME [ -v ] -d PACKAGE_NAME[=VERSION]
    or: $SCRIPT_NAME [ -v ] -d PACKAGE_NAME[/ARCHIVE]
 
-The package to examine can be specified by either the filename of a .deb 
-package or a package name. If a package name is provided, $SCRIPT_NAME will 
-attempt to find it in $APT_ARCHIVE. If it is not found there 
-and the "-d" option is specified, $SCRIPT_NAME will attempt to download the 
-package using aptitude(8). 
+The package to examine can be specified by either the filename of a .deb
+package or a package name. If a package name is provided, $SCRIPT_NAME will
+attempt to find it in $APT_ARCHIVE. If it is not found there
+and the "-d" option is specified, $SCRIPT_NAME will attempt to download the
+package using aptitude(8).
 
 PACKAGE_NAME can use "aptitude download" syntax. When searching locally, a
 version restriction can be specified with an "=VERSION" suffix. When the "-d"
@@ -108,7 +109,7 @@ Options:
   -d    If PACKAGE_NAME is not found in $APT_ARCHIVE, attempt
         to download it to a temporary directory using aptitude(8).
   -h    Print this help text.
-  -v    Verbose output (give output for every file processed, not just 
+  -v    Verbose output (give output for every file processed, not just
         files that differ)
 EOF
 }
@@ -118,7 +119,7 @@ function getCachedDebFile {
    pkgNameSpec=${1%=*}
    version=${1#*=}
    candidates="$APT_ARCHIVE/${pkgNameSpec}_${version}_*.deb"
-   if [ -z "$version" -o "$version" = "$1" ]; then
+   if [[ -z "$version" || "$version" = "$1" ]]; then
       if version_arch=$(dpkg-query -W -f '${Version}_${Architecture}' "$pkgNameSpec" 2>/dev/null); then
          # Replace ":" (the epoch separator) with "%3a" to match the file name.
          foundFile="$APT_ARCHIVE/${pkgNameSpec}_${version_arch/:/%3a}.deb"
@@ -127,23 +128,23 @@ function getCachedDebFile {
       fi
    fi
    if [ -z "$foundFile" ]; then
-      if echo $candidates | grep -q ' '; then
+      if echo "$candidates" | grep -q ' '; then
          echo "Found more than one file in $APT_ARCHIVE matching \"$1\":" >&2
-         for i in $candidates; do 
+         for i in $candidates; do
             echo " ${i##*/}" >&2
          done
-	 die "Please provide a more precise package specification."
+     die "Please provide a more precise package specification."
       else
-         foundFile=$(echo $candidates)
+         foundFile="$candidates"
       fi
    fi
-   if [ ! -e $foundFile ]; then
+   if [ ! -e "$foundFile" ]; then
       echo "No package matching \"$1\" found in cache." >&2
-   elif [ -r $foundFile ]; then
-      echo $foundFile
+   elif [ -r "$foundFile" ]; then
+      echo "$foundFile"
       return 0
    else
-      echo "Found matching file in cache, but it cannot be read:" $foundFile >&2
+      echo "Found matching file in cache, but it cannot be read: $foundFile" >&2
    fi
    return 1
 }
@@ -151,11 +152,11 @@ function getCachedDebFile {
 function downloadDebFile {
    tempDirReady || die "Temporary directory not available. Cannot download with aptitude."
 
-   cd "$tempDir"
-   aptitude download $1 >&2 || die "Aptitude download failed."
+   cd "$tempDir" || echo "$tempDir directory is not accessible." || exit 1
+   aptitude download "$1" >&2 || die "Aptitude download failed."
    # Strip = and / modifiers from package name.
    pkgName=${1%[=/]*}
-   echo "$tempDir"/${pkgName}*.deb
+   echo "$tempDir"/"${pkgName}"*.deb
 }
 
 # Handle interrupt.
@@ -166,11 +167,14 @@ while getopts "hvd" opt; do
    case $opt in
       h)
          printUsage
-	 exit 0 ;;
+         exit 0 ;;
       v) verbose=1 ;;
       d) download=1 ;;
+      *)
+         printUsage
+         exit 0;;
    esac
-done   
+done
 shift $((OPTIND-1))
 
 if [ -z "$1" ]; then
@@ -186,8 +190,8 @@ case $1 in
    *)
       if [ $download ]; then
          debFile=$(getCachedDebFile "$1" || downloadDebFile "$1") || die
-      else 
-         debFile=$(getCachedDebFile "$1") || die 
+      else
+         debFile=$(getCachedDebFile "$1") || die
       fi ;;
 esac
 
@@ -199,54 +203,54 @@ extractDir=$tempDir/$(basename "$debFile" .deb)
 
 mkdir "$extractDir" || die "Unable to create extraction directory: $extractDir"
 
-dpkg-deb -X "$debFile" "$extractDir" | waitNext | while read filename; do
+dpkg-deb -X "$debFile" "$extractDir" | waitNext | while read -r filename; do
    relname=${filename#./}
-   
+
    pkgFile=$extractDir/$relname
    fsFile=/${relname%/}
-  
+
    if [ ! -e "$fsFile" ]; then
       echo "Not present: $fsFile"
    elif [ -L "$pkgFile" ]; then
       # Handle symbolic links by comparing their target strings
       if [ ! -L "$fsFile" ]; then
          echo "Package file is symlink but current file is not: $fsFile"
-	 continue
+     continue
       fi
-	 
+
       pkgLink=$(readlink "$pkgFile")
       fsLink=$(readlink "$fsFile")
-	 
+
       if [ "$pkgLink" != "$fsLink" ]; then
          echo "Target of symbolic link differs: $fsFile"
-	 echo " Packaged -> $pkgLink"
-	 echo " Current  -> $fsLink"
+     echo " Packaged -> $pkgLink"
+     echo " Current  -> $fsLink"
       fi
    elif [ -L "$fsFile" ]; then
       # (! -L $pkgFile) implied by failure of previous elif
       echo "Current file is symlink but package file is not: $fsFile"
-   elif [ -f "$fsFile" -a -d "$pkgFile" ]; then
+   elif [[ -f "$fsFile" && -d "$pkgFile" ]]; then
       echo "Currently regular file, but directory in package: $fsFile"
-   elif [ -d "$fsFile" -a -f "$pkgFile" ]; then
-      echo "Currently directory, but regular file in package: $fsFile"   
+   elif [[ -d "$fsFile" && -f "$pkgFile" ]]; then
+      echo "Currently directory, but regular file in package: $fsFile"
    elif [ -f "$fsFile" ]; then
       if [ ! -r "$fsFile" ]; then
          echo "Exists but cannot read: $fsFile"
       else
          case "$pkgFile" in
-	    *.gz)
-	       cmp -s "$pkgFile" "$fsFile" || {
-	         echo "zdiff for $fsFile:"
-	         zdiff -u "$pkgFile" "$fsFile" 
-	       } ;;
-	    *.bz2)
-	       cmp -s "$pkgFile" "$fsFile" || {
-	          echo "bzdiff for $fsFile:"
-	          bzdiff -u "$pkgFile" "$fsFile" 
-	       } ;;
-	    *)
+        *.gz)
+           cmp -s "$pkgFile" "$fsFile" || {
+             echo "zdiff for $fsFile:"
+             zdiff -u "$pkgFile" "$fsFile"
+           } ;;
+        *.bz2)
+           cmp -s "$pkgFile" "$fsFile" || {
+              echo "bzdiff for $fsFile:"
+              bzdiff -u "$pkgFile" "$fsFile"
+           } ;;
+        *)
                diff -u "$pkgFile" "$fsFile" ;;
-	 esac && test $verbose && echo "Same: $fsFile"
+     esac && test $verbose && echo "Same: $fsFile"
       fi
    fi
 done


### PR DESCRIPTION
this is basically a strengthened dpkg-diffs that now works with filenames having a blank character in it.

also works with apt as well as aptitude as some platform do not have aptitude installed (most servers).